### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **React Native Turbo Module library** (`rn-encryption`) providing cross-platform encryption (AES, RSA, ECDSA, SHA, HMAC, Base64, file encryption). It is **not a standalone application** — the `example/` directory contains a React Native example app for on-device testing, but the library itself is the primary development target.
+
+### Key development commands
+
+All commands are documented in `CONTRIBUTING.md` and `package.json` scripts. Quick reference:
+
+- `yarn lint` — ESLint (0 errors expected; 2 inline-style warnings in example app are pre-existing)
+- `yarn typecheck` — TypeScript type-checking
+- `yarn test` — Jest unit tests
+- `yarn prepare` — Build the library (CJS, ESM, TS declarations, codegen) via `react-native-builder-bob`
+
+### Environment notes
+
+- **Node.js v18** is required (see `.nvmrc`). Use `nvm use 18` before running commands.
+- **Yarn 3.6.1** (Berry) is bundled in `.yarn/releases/yarn-3.6.1.cjs`. Do not use npm.
+- The example app (`example/`) requires iOS/Android SDKs and simulators/emulators which are not available in the Cloud Agent VM. Library-level verification (lint, typecheck, test, build) is sufficient for CI-like validation.
+- The `web-secure-encryption` dependency provides the web implementation and can be exercised in Node.js by polyfilling `globalThis.crypto` with `require('crypto').webcrypto`.
+- Pre-commit hooks are configured via `lefthook.yml` (runs lint + typecheck on staged files).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

### What's included

- Key development commands reference (lint, typecheck, test, build)
- Environment notes: Node.js v18 requirement, Yarn 3.6.1 Berry, example app limitations in Cloud VM
- `web-secure-encryption` polyfill tip for Node.js testing
- Pre-commit hooks note (lefthook)

### Verification

All development commands verified working:

[dev_environment_verification.log](https://cursor.com/agents/bc-15f524aa-2fe6-4be2-a57b-44d07ffecd31/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15f524aa-2fe6-4be2-a57b-44d07ffecd31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15f524aa-2fe6-4be2-a57b-44d07ffecd31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

