### PR TITLE
feat: implement signDataRSA and verifySignatureRSA across all platforms

### DIFF
--- a/android/src/main/java/com/encryption/EncryptionModule.kt
+++ b/android/src/main/java/com/encryption/EncryptionModule.kt
@@ -399,6 +399,37 @@ override fun getPublicRSAkey(privateKeyBase64: String): String {
         }
 
         // -----------------------------------------
+        // ✍️ RSA Signing and Verification
+        // -----------------------------------------
+
+        /**
+         * Signs data using an RSA private key with SHA256withRSA.
+         *
+         * @param data The plaintext data to sign.
+         * @param key The Base64-encoded RSA private key.
+         * @return A Base64-encoded digital signature string.
+         * @throws Exception If signing fails due to invalid key format or other errors.
+         */
+        @Throws(Exception::class)
+        override fun signDataRSA(data: String, key: String): String {
+            return SignatureUtils.signDataRSA(data, key)
+        }
+
+        /**
+         * Verifies an RSA signature against the provided data and public key.
+         *
+         * @param data The original plaintext data.
+         * @param signatureBase64 The Base64-encoded digital signature.
+         * @param key The Base64-encoded RSA public key used for verification.
+         * @return `true` if the signature is valid, otherwise `false`.
+         * @throws Exception If verification fails due to invalid key format or other errors.
+         */
+        @Throws(Exception::class)
+        override fun verifySignatureRSA(data: String, signatureBase64: String, key: String): Boolean {
+            return SignatureUtils.verifySignatureRSA(data, signatureBase64, key)
+        }
+
+        // -----------------------------------------
         // 🛡️ SHA Hashing
         // -----------------------------------------
 

--- a/android/src/main/java/com/encryption/SignatureUtils.kt
+++ b/android/src/main/java/com/encryption/SignatureUtils.kt
@@ -32,7 +32,7 @@ object SignatureUtils {
             signature.update(data.toByteArray(Charsets.UTF_8))
 
             val signedData = signature.sign()
-            Base64.encodeToString(signedData, Base64.DEFAULT)
+            Base64.encodeToString(signedData, Base64.NO_WRAP)
         } catch (e: Exception) {
             e.printStackTrace()
             throw Exception("Failed to sign data with RSA: ${e.localizedMessage}")

--- a/android/src/main/java/com/encryption/SignatureUtils.kt
+++ b/android/src/main/java/com/encryption/SignatureUtils.kt
@@ -8,9 +8,65 @@ import java.security.interfaces.ECPublicKey
 import java.math.BigInteger
 
 /**
- * SignatureUtils: Utility class for ECDSA Key Pair Management, Signing, and Verification.
+ * SignatureUtils: Utility class for ECDSA and RSA Key Pair Management, Signing, and Verification.
  */
 object SignatureUtils {
+
+    /**
+     * Signs data using an RSA private key with SHA256withRSA.
+     *
+     * @param data The plaintext data to sign.
+     * @param privateKeyBase64 The Base64-encoded RSA private key (PKCS#8).
+     * @return Base64-encoded digital signature.
+     */
+    @Throws(Exception::class)
+    fun signDataRSA(data: String, privateKeyBase64: String): String {
+        return try {
+            val privateKeyBytes = Base64.decode(privateKeyBase64, Base64.DEFAULT)
+            val keyFactory = KeyFactory.getInstance("RSA")
+            val privateKeySpec = PKCS8EncodedKeySpec(privateKeyBytes)
+            val privateKey = keyFactory.generatePrivate(privateKeySpec)
+
+            val signature = Signature.getInstance("SHA256withRSA")
+            signature.initSign(privateKey)
+            signature.update(data.toByteArray(Charsets.UTF_8))
+
+            val signedData = signature.sign()
+            Base64.encodeToString(signedData, Base64.DEFAULT)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw Exception("Failed to sign data with RSA: ${e.localizedMessage}")
+        }
+    }
+
+    /**
+     * Verifies an RSA signature using the provided public key with SHA256withRSA.
+     *
+     * @param data The original plaintext data.
+     * @param signatureBase64 The Base64-encoded digital signature.
+     * @param publicKeyBase64 The Base64-encoded RSA public key (X.509).
+     * @return `true` if the signature is valid, `false` otherwise.
+     */
+    @Throws(Exception::class)
+    fun verifySignatureRSA(data: String, signatureBase64: String, publicKeyBase64: String): Boolean {
+        return try {
+            val publicKeyBytes = Base64.decode(publicKeyBase64, Base64.DEFAULT)
+            val keyFactory = KeyFactory.getInstance("RSA")
+            val publicKeySpec = X509EncodedKeySpec(publicKeyBytes)
+            val publicKey = keyFactory.generatePublic(publicKeySpec)
+
+            val signature = Signature.getInstance("SHA256withRSA")
+            signature.initVerify(publicKey)
+            signature.update(data.toByteArray(Charsets.UTF_8))
+
+            val signatureBytes = Base64.decode(signatureBase64, Base64.DEFAULT)
+            signature.verify(signatureBytes)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw Exception("Failed to verify RSA signature: ${e.localizedMessage}")
+        }
+    }
+
 
     /**
      * Generates an ECDSA (Elliptic Curve Digital Signature Algorithm) key pair.

--- a/ios/Encryption.mm
+++ b/ios/Encryption.mm
@@ -399,6 +399,34 @@ RCT_EXPORT_MODULE()
 }
 
 
+#pragma mark - RSA Signing and Verification
+
+- (NSString *)signDataRSA:(NSString *)data key:(NSString *)key {
+    NSError *error = nil;
+    NSString *signedString = [cryptoUtil signDataRSA:data privateKeyBase64:key errorObj:&error];
+    
+    if (error) {
+        @throw [NSException exceptionWithName:@"EncryptionError"
+                                       reason:error.localizedDescription
+                                     userInfo:nil];
+    } else {
+        return signedString;
+    }
+}
+
+- (NSNumber *)verifySignatureRSA:(NSString *)data signatureBase64:(NSString *)signature key:(NSString *)key {
+    NSError *error = nil;
+    BOOL isValid = [cryptoUtil verifySignatureRSA:data signatureBase64:signature publicKeyBase64:key errorObj:&error];
+    
+    if (error) {
+        @throw [NSException exceptionWithName:@"EncryptionError"
+                                       reason:error.localizedDescription
+                                     userInfo:nil];
+    } else {
+        return @(isValid);
+    }
+}
+
 #pragma mark - Hashing
 
 // SHA-256 Hashing

--- a/ios/EncryptionCryptokitIml.swift
+++ b/ios/EncryptionCryptokitIml.swift
@@ -546,6 +546,99 @@ public class CryptoUtility: NSObject {
             }
         }
     
+    // MARK: - RSA Signing
+    
+    /// Signs data using an RSA private key with PKCS1v15 + SHA-256.
+    /// - Parameters:
+    ///   - data: The plain text data to sign.
+    ///   - privateKeyBase64: Base64-encoded RSA private key.
+    ///   - errorObj: NSErrorPointer for capturing errors.
+    /// - Returns: Base64-encoded signature string or nil on failure.
+    @objc public func signDataRSA(_ data: String, privateKeyBase64: String, errorObj: NSErrorPointer) -> String? {
+        do {
+            let privateKey = try constructSecKey(from: privateKeyBase64, isPublicKey: false)
+            
+            guard let dataToSign = data.data(using: .utf8) else {
+                throw EncryptionError.invalidData
+            }
+            
+            var error: Unmanaged<CFError>?
+            guard let signatureData = SecKeyCreateSignature(
+                privateKey,
+                .rsaSignatureMessagePKCS1v15SHA256,
+                dataToSign as CFData,
+                &error
+            ) as Data? else {
+                throw error?.takeRetainedValue() ?? EncryptionError.encryptionFailed
+            }
+            
+            return signatureData.base64EncodedString()
+        } catch let encryptionError as EncryptionError {
+            errorObj?.pointee = NSError(
+                domain: "CryptoUtility",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: encryptionError.localizedDescription]
+            )
+            return nil
+        } catch {
+            errorObj?.pointee = NSError(
+                domain: "CryptoUtility",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "An unknown RSA signing error occurred."]
+            )
+            return nil
+        }
+    }
+    
+    // MARK: - RSA Signature Verification
+    
+    /// Verifies an RSA signature using PKCS1v15 + SHA-256.
+    /// - Parameters:
+    ///   - data: The original plain text data.
+    ///   - signatureBase64: Base64-encoded signature.
+    ///   - publicKeyBase64: Base64-encoded RSA public key.
+    ///   - errorObj: NSErrorPointer for capturing errors.
+    /// - Returns: Boolean indicating whether the signature is valid.
+    @objc public func verifySignatureRSA(_ data: String, signatureBase64: String, publicKeyBase64: String, errorObj: NSErrorPointer) -> Bool {
+        do {
+            let publicKey = try constructSecKey(from: publicKeyBase64, isPublicKey: true)
+            
+            guard let dataToVerify = data.data(using: .utf8),
+                  let signatureData = Data(base64Encoded: signatureBase64) else {
+                throw EncryptionError.invalidData
+            }
+            
+            var error: Unmanaged<CFError>?
+            let isValid = SecKeyVerifySignature(
+                publicKey,
+                .rsaSignatureMessagePKCS1v15SHA256,
+                dataToVerify as CFData,
+                signatureData as CFData,
+                &error
+            )
+            
+            if let cfError = error {
+                throw cfError.takeRetainedValue()
+            }
+            
+            return isValid
+        } catch let encryptionError as EncryptionError {
+            errorObj?.pointee = NSError(
+                domain: "CryptoUtility",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: encryptionError.localizedDescription]
+            )
+            return false
+        } catch {
+            errorObj?.pointee = NSError(
+                domain: "CryptoUtility",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "An unknown RSA verification error occurred."]
+            )
+            return false
+        }
+    }
+    
     // MARK: - Hashing (SHA256 & SHA512)
     
     /// Generate a hashSHA256 base64 key as string

--- a/ios/EncryptionCryptokitIml.swift
+++ b/ios/EncryptionCryptokitIml.swift
@@ -617,11 +617,14 @@ public class CryptoUtility: NSObject {
                 &error
             )
             
-            if let cfError = error {
-                throw cfError.takeRetainedValue()
+            if !isValid {
+                if let cfError = error {
+                    cfError.release()
+                }
+                return false
             }
             
-            return isValid
+            return true
         } catch let encryptionError as EncryptionError {
             errorObj?.pointee = NSError(
                 domain: "CryptoUtility",

--- a/src/NativeEncryption.ts
+++ b/src/NativeEncryption.ts
@@ -23,6 +23,12 @@ export interface Spec extends TurboModule {
   decryptRSA(data: string, privateKey: string): string;
   encryptAsyncRSA(data: string, publicKey: string): Promise<string>;
   decryptAsyncRSA(data: string, privateKey: string): Promise<string>;
+  signDataRSA(data: string, key: string): string;
+  verifySignatureRSA(
+    data: string,
+    signatureBase64: string,
+    key: string
+  ): boolean;
 
   hashSHA256(input: string): string;
   hashSHA512(input: string): string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,12 @@ type EncryptionModule = {
   encryptRSA(data: string, key: string): string;
   decryptRSA(data: string, key: string): string;
   generateRSAKeyPair(): KeyPair;
+  signDataRSA(data: string, key: string): string;
+  verifySignatureRSA(
+    data: string,
+    signatureBase64: string,
+    key: string
+  ): boolean;
   generateHMACKey(keySize: number): string;
   hmacSHA256(data: string, key: string): string;
   hmacSHA512(data: string, key: string): string;
@@ -73,6 +79,18 @@ export function decryptRSA(data: string, key: string): string {
 
 export function generateRSAKeyPair(): KeyPair {
   return Encryption.generateRSAKeyPair();
+}
+
+export function signDataRSA(data: string, key: string): string {
+  return Encryption.signDataRSA(data, key);
+}
+
+export function verifySignatureRSA(
+  data: string,
+  signatureBase64: string,
+  key: string
+): boolean {
+  return Encryption.verifySignatureRSA(data, signatureBase64, key);
 }
 
 export function generateHMACKey(keySize: number): string {

--- a/src/native/index.tsx
+++ b/src/native/index.tsx
@@ -72,6 +72,18 @@ export function getPublicRSAkey(privateRSAkey: string): string {
   return Encryption.getPublicRSAkey(privateRSAkey);
 }
 
+export function signDataRSA(data: string, key: string): string {
+  return Encryption.signDataRSA(data, key);
+}
+
+export function verifySignatureRSA(
+  data: string,
+  signatureBase64: string,
+  key: string
+): boolean {
+  return Encryption.verifySignatureRSA(data, signatureBase64, key);
+}
+
 export function generateECDSAKeyPair(): keypair {
   return Encryption.generateECDSAKeyPair();
 }

--- a/src/web/index.tsx
+++ b/src/web/index.tsx
@@ -43,6 +43,15 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
   return bytes.buffer as ArrayBuffer;
 }
 
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
 function stringToUtf8Bytes(str: string): Uint8Array {
   return new TextEncoder().encode(str);
 }
@@ -156,4 +165,51 @@ export async function getPublicRSAkey(
     binary += String.fromCharCode(spkiBytes[i]!);
   }
   return btoa(binary);
+}
+
+// --- RSA Sign/Verify: RSASSA-PKCS1-v1_5 + SHA-256, async on web ---
+
+export async function signDataRSA(
+  data: string,
+  privateKeyBase64: string
+): Promise<string> {
+  const keyData = base64ToArrayBuffer(privateKeyBase64);
+  const privateKey = await crypto.subtle.importKey(
+    'pkcs8',
+    keyData,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const dataBytes = stringToUtf8Bytes(data);
+  const signature: ArrayBuffer = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    privateKey,
+    dataBytes
+  );
+  return arrayBufferToBase64(signature);
+}
+
+export async function verifySignatureRSA(
+  data: string,
+  signatureBase64: string,
+  publicKeyBase64: string
+): Promise<boolean> {
+  const keyData = base64ToArrayBuffer(publicKeyBase64);
+  const publicKey = await crypto.subtle.importKey(
+    'spki',
+    keyData,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['verify']
+  );
+  const signatureBytes = base64ToArrayBuffer(signatureBase64);
+  const dataBytes = stringToUtf8Bytes(data);
+  const result: boolean = await crypto.subtle.verify(
+    'RSASSA-PKCS1-v1_5',
+    publicKey,
+    signatureBytes,
+    dataBytes
+  );
+  return result;
 }

--- a/src/web/index.tsx
+++ b/src/web/index.tsx
@@ -35,7 +35,8 @@ function arrayBufferToHex(buffer: ArrayBuffer): string {
 }
 
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  const binaryString: string = atob(base64);
+  const cleaned = base64.replace(/\s/g, '');
+  const binaryString: string = atob(cleaned);
   const bytes = new Uint8Array(binaryString.length);
   for (let i = 0; i < binaryString.length; i++) {
     bytes[i] = binaryString.charCodeAt(i);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds RSA digital signature support (`signDataRSA` and `verifySignatureRSA`) across all platforms, mirroring the existing ECDSA sign/verify pattern.

## Changes

### TypeScript Layer
- **`src/NativeEncryption.ts`** — Added `signDataRSA(data, key): string` and `verifySignatureRSA(data, signatureBase64, key): boolean` to the Turbo Module spec
- **`src/native/index.tsx`** — Added typed wrapper functions for native bridge
- **`src/index.tsx`** — Exported both new methods
- **`src/web/index.tsx`** — Implemented using Web Crypto API (`RSASSA-PKCS1-v1_5` with SHA-256)

### iOS (Swift + ObjC++)
- **`ios/EncryptionCryptokitIml.swift`** — `signDataRSA` uses `SecKeyCreateSignature` with `.rsaSignatureMessagePKCS1v15SHA256`; `verifySignatureRSA` uses `SecKeyVerifySignature` with the same algorithm. Reuses existing `constructSecKey` helper.
- **`ios/Encryption.mm`** — Bridge methods delegate to `CryptoUtility`

### Android (Kotlin)
- **`android/.../SignatureUtils.kt`** — `signDataRSA` and `verifySignatureRSA` using `SHA256withRSA` via `java.security.Signature`, matching the ECDSA pattern
- **`android/.../EncryptionModule.kt`** — `override` methods delegate to `SignatureUtils`

### Algorithm
| Platform | Sign | Verify |
|---|---|---|
| iOS | `SecKeyCreateSignature` + `.rsaSignatureMessagePKCS1v15SHA256` | `SecKeyVerifySignature` + `.rsaSignatureMessagePKCS1v15SHA256` |
| Android | `Signature.getInstance("SHA256withRSA")` | `Signature.getInstance("SHA256withRSA")` |
| Web | `crypto.subtle.sign("RSASSA-PKCS1-v1_5")` | `crypto.subtle.verify("RSASSA-PKCS1-v1_5")` |

## Usage

```tsx
import { generateRSAKeyPair, signDataRSA, verifySignatureRSA } from 'rn-encryption';

const keys = generateRSAKeyPair();
const data = 'Hello, RSA Signing!';
const signature = signDataRSA(data, keys.privateKey);
const isValid = verifySignatureRSA(data, signature, keys.publicKey);
// isValid === true
```

## Testing

Verification log showing lint, typecheck, test, build, and RSA sign/verify all passing:

[verification_output.log](https://cursor.com/agents/bc-15f524aa-2fe6-4be2-a57b-44d07ffecd31/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverification_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15f524aa-2fe6-4be2-a57b-44d07ffecd31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15f524aa-2fe6-4be2-a57b-44d07ffecd31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

